### PR TITLE
Use ES6 modules and target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es5",
+    "module": "es6",
+    "target": "es6",
     "declaration": true,
     "outDir": "./dist"
   },


### PR DESCRIPTION
Avoid Angular warnings for old CommonJS module usage (see https://angular.io/guide/build#configuring-commonjs-dependencies)

FIXES #2 